### PR TITLE
support no-ending slash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 // Replace absolute file paths with <PROJECT_ROOT>
 
-const dirname = __dirname.substring(0, __dirname.indexOf('/node_modules/') + 1)
+const dirname = __dirname.substring(0, __dirname.indexOf('/node_modules/'))
 
 module.exports = {
   print (val/* : Object */, serialize/* : Function */) {
@@ -10,7 +10,7 @@ module.exports = {
     if (isPath(val)) {
 
       // eslint-disable-next-line
-      val = val.replace(dirname, '<PROJECT_ROOT>/')
+      val = val.replace(dirname, '<PROJECT_ROOT>')
 
     }
     else {
@@ -20,7 +20,7 @@ module.exports = {
         if (isPath(val[key])) {
 
           // eslint-disable-next-line
-          val[key] = val[key].replace(dirname, '<PROJECT_ROOT>/')
+          val[key] = val[key].replace(dirname, '<PROJECT_ROOT>')
 
         }
 


### PR DESCRIPTION
If the path doesn't include the ending slash then it wasn't picked up by this serializer. So this removes the ending slash from `dirname` and simply replaces the "naked" dirname with a "naked" `PROJECT_ROOT` :+1: