### PR TITLE
Add AppVeyor Windows Continuous Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # jest-serializer-path
 
 [![npm version](https://badge.fury.io/js/jest-serializer-path.svg)](https://badge.fury.io/js/jest-serializer-path)
-[![CircleCI](https://circleci.com/gh/tribou/jest-serializer-path.svg?style=svg)](https://circleci.com/gh/tribou/jest-serializer-path)
+[![Linux Build Status](https://img.shields.io/circleci/project/github/tribou/jest-serializer-path/master.svg?label=linux%20build)](https://circleci.com/gh/tribou/jest-serializer-path/tree/master)
+[![Windows Build Status](https://img.shields.io/appveyor/ci/tribou/jest-serializer-path/master.svg?label=windows%20build)](https://ci.appveyor.com/project/tribou/jest-serializer-path/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/tribou/jest-serializer-path/badge.svg?branch=master)](https://coveralls.io/github/tribou/jest-serializer-path?branch=master)
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
 [![bitHound Code](https://www.bithound.io/github/tribou/jest-serializer-path/badges/code.svg)](https://www.bithound.io/github/tribou/jest-serializer-path)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,13 @@ environment:
     - nodejs_version: '8'
 install:
   - ps: Install-Product node $env:nodejs_version
-  - yarn install
+  - npm run yarn
 matrix:
   fast_finish: true
 build: off
 shallow_clone: true
 test_script:
   - node --version
-  - yarn --version
-  - yarn test
+  - npm run test
 cache:
   - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  matrix:
+    - nodejs_version: '6'
+    - nodejs_version: '8'
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - yarn install
+matrix:
+  fast_finish: true
+build: off
+shallow_clone: true
+test_script:
+  - node --version
+  - yarn --version
+  - yarn test
+cache:
+  - "%LOCALAPPDATA%\\Yarn"

--- a/package.json
+++ b/package.json
@@ -9,11 +9,6 @@
     "node": ">=6.4.x",
     "npm": ">=3.10.3"
   },
-  "config": {
-    "yarn": {
-      "version": "1.3.2"
-    }
-  },
   "homepage": "https://github.com/tribou/jest-serializer-path#readme",
   "repository": {
     "type": "git",
@@ -56,6 +51,6 @@
     "test": "npm run --silent lint && npm run --silent test-jest",
     "watch": "npm run test-jest -- --watch",
     "yarn": "npm run --silent yarn-bin -- install --prefer-offline",
-    "yarn-bin": "node bin/yarn-${npm_package_config_yarn_version}.js"
+    "yarn-bin": "node bin/yarn-1.3.2.js"
   }
 }


### PR DESCRIPTION
This PR adds AppVeyor Windows Continuous Integration to ensure all tests pass in Windows. You'll need to create an account at https://www.appveyor.com/ and add this project. 

I've never tried using this with Yarn, but according to [yarnpkg.com/docs/install-ci/#appveyor](https://yarnpkg.com/lang/en/docs/install-ci/#appveyor), it should work without issue. Let me know if you have any issues / questions.