### PR TITLE
handle changes to process.chdir / process.cwd

### DIFF
--- a/lib/__snapshots__/index_test.js.snap
+++ b/lib/__snapshots__/index_test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`serializer handles process.chdir <PROJECT_ROOT> 1`] = `"<PROJECT_ROOT>/src/somewhere"`;
+
 exports[`serializer preserves path directories after the <PROJECT_ROOT> 1`] = `"<PROJECT_ROOT>/src/somewhere"`;
 
 exports[`serializer replaces every instance of process.cwd in the same string 1`] = `
@@ -18,12 +20,12 @@ Object {
 }
 `;
 
+exports[`serializer replaces process.cwd with <PROJECT_ROOT> in an Error 1`] = `[Error: some error in <PROJECT_ROOT>/a/path]`;
+
 exports[`serializer replaces process.cwd with <PROJECT_ROOT> in array 1`] = `
 Array [
   "<PROJECT_ROOT>/src",
 ]
 `;
-
-exports[`serializer replaces process.cwd with <PROJECT_ROOT> in an Error 1`] = `[Error: some error in <PROJECT_ROOT>/a/path]`;
 
 exports[`serializer supports trailing slashes in the path 1`] = `"<PROJECT_ROOT>/path/with/trailing/slash/"`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,10 @@
 /* eslint-disable no-param-reassign */
 
 // Replace absolute file paths with <PROJECT_ROOT>
-
-const cwd = process.cwd()
-
 module.exports = {
   print (val, serialize) {
+
+    const cwd = process.cwd()
 
     if (isPath(val)) {
 
@@ -70,6 +69,8 @@ module.exports = {
 }
 
 function isPath (value) {
+
+  const cwd = process.cwd()
 
   return typeof value === 'string'
     && value.indexOf(cwd) !== -1

--- a/lib/index_test.js
+++ b/lib/index_test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const path = require('path')
 const Serializer = require('./')
 
 describe('serializer', () => {
@@ -46,6 +47,20 @@ describe('serializer', () => {
 
     const sut = `${process.cwd()}/path/with/trailing/slash/`
     expect(sut).toMatchSnapshot()
+
+  })
+
+  it('handles process.chdir <PROJECT_ROOT>', () => {
+
+    const cwd = process.cwd()
+
+    const cwdUpdated = path.join(cwd, 'lib')
+    process.chdir(cwdUpdated)
+
+    const sut = `${process.cwd()}/src/somewhere`
+    expect(sut).toMatchSnapshot()
+
+    process.chdir(cwd)
 
   })
 


### PR DESCRIPTION
Currently if a test uses ``process.chdir`` to update ``process.cwd``, <PROJECT_ROOT> ignores this update. This change fixes that. Test included.