### PR TITLE
fix: handle error-like objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,12 +9,14 @@ const path = require('path')
 module.exports = {
   print (val, serialize) {
 
-    if (val instanceof Error) {
+    if (typeof val === 'object') {
 
-      val.message = normalizePaths(val.message)
+      // val.message is non-enumerable in an error
+      if (val.message) {
 
-    }
-    else if (typeof val === 'object') {
+        val.message = normalizePaths(val.message)
+
+      }
 
       Object.keys(val).forEach(key => {
 
@@ -36,12 +38,14 @@ module.exports = {
 
     let has = false
 
-    if (val instanceof Error && shouldUpdate(val.message)) {
+    if (val && typeof val === 'object') {
 
-      has = true
+      // val.message is non-enumerable in an error
+      if (val.message && shouldUpdate(val.message)) {
 
-    }
-    else if (val && typeof val === 'object') {
+        has = true
+
+      }
 
       Object.keys(val).forEach(key => {
 

--- a/lib/index_test.js
+++ b/lib/index_test.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const path = require('path')
-const Serializer = require('./')
 const os = require('os')
+const fs = require('fs')
+const Serializer = require('./')
 
 const normalizePaths = Serializer.normalizePaths
 
@@ -154,12 +155,30 @@ describe('serializer.test()', () => {
 
   })
 
-  it('returns true when val is an object with a property that contains process.cwd', () => {
+  it('returns true when val is an error with a property that contains process.cwd', () => {
 
     const val = new Error(`some error in ${path.resolve(process.cwd(), 'a/path')}`)
     val.code = 'HAS_CODE'
     const result = Serializer.test(val)
     expect(result).toEqual(true)
+
+  })
+
+  it('returns true when error-like has process.cwd', () => {
+
+    try {
+
+      const fsDoesNotExist = path.resolve(process.cwd(), 'a/b/c/d/e/f/none.js')
+      fs.readFileSync(fsDoesNotExist)
+
+    }
+    catch (error) {
+
+      // error is not an instanceof Error
+      const result = Serializer.test(error)
+      expect(result).toEqual(true)
+
+    }
 
   })
 
@@ -219,6 +238,55 @@ describe('serializer.print()', () => {
     const expected = 'some error in <PROJECT_ROOT>/a/path'
     Serializer.print(val, ser)
     expect(ser.mock.calls[0][0].message).toEqual(expected)
+
+  })
+
+  it('replaces process.cwd with <PROJECT_ROOT> in string property when val is error-like on all values', () => {
+
+    try {
+
+      const fsDoesNotExist = path.resolve(process.cwd(), 'a/b/c/d/e/f/none.js')
+      fs.readFileSync(fsDoesNotExist)
+
+    }
+    catch (error) {
+
+      const ser = jest.fn()
+
+      error.code = path.resolve(process.cwd(), 'some/fake/error/code')
+
+      const expectedMessage = `ENOENT: no such file or directory, open '<PROJECT_ROOT>/a/b/c/d/e/f/none.js'`
+      const expectedCode = '<PROJECT_ROOT>/some/fake/error/code'
+      Serializer.print(error, ser)
+      expect(ser.mock.calls[0][0].message).toEqual(expectedMessage)
+      expect(ser.mock.calls[0][0].code).toEqual(expectedCode)
+
+    }
+
+  })
+
+  it('replaces process.cwd with <PROJECT_ROOT> in string property when val is error-like but not in message', () => {
+
+    try {
+
+      const fsDoesNotExist = path.resolve(process.cwd(), 'a/b/c/d/e/f/none.js')
+      fs.readFileSync(fsDoesNotExist)
+
+    }
+    catch (error) {
+
+      const ser = jest.fn()
+
+      error.message = 'no path found'
+      error.code = path.resolve(process.cwd(), 'some/fake/error/code')
+
+      const expectedMessage = `no path found`
+      const expectedCode = '<PROJECT_ROOT>/some/fake/error/code'
+      Serializer.print(error, ser)
+      expect(ser.mock.calls[0][0].message).toEqual(expectedMessage)
+      expect(ser.mock.calls[0][0].code).toEqual(expectedCode)
+
+    }
 
   })
 


### PR DESCRIPTION
When moving one of my bigger projects to use this plugin I found that not all errors return ``true`` for ``instanceof Error``.

This PR fixes it with tests.