### PR TITLE
Fix NaN

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,9 +115,13 @@ function normalizePaths (value) {
 }
 
 function shouldUpdate (value) {
+
+  /* eslint-disable no-self-compare */
   // NaN is the only JS value which never equals itself
   if (value !== value) {
+
     return false
+
   }
 
   // return true if value is different from normalized value

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,10 @@ function normalizePaths (value) {
 }
 
 function shouldUpdate (value) {
+  // NaN is the only JS value which never equals itself
+  if (value !== value) {
+    return false
+  }
 
   // return true if value is different from normalized value
   return normalizePaths(value) !== value

--- a/lib/index_test.js
+++ b/lib/index_test.js
@@ -190,6 +190,14 @@ describe('serializer.test()', () => {
 
   })
 
+  it('returns false when value is NaN', () => {
+
+    const val = NaN
+    const result = Serializer.test(val)
+    expect(result).toEqual(false)
+
+  })
+
 })
 
 


### PR DESCRIPTION
Hit an interesting one. I had a NaN in a snapshot, causing a `RangeError: Maximum call stack size exceeded` because pretty-formatter and jest-serializer-path kept going back and forth.