### PR TITLE
Jest refactors / optimizations

### DIFF
--- a/lib/index_test.js
+++ b/lib/index_test.js
@@ -3,9 +3,9 @@
 const path = require('path')
 const os = require('os')
 const fs = require('fs')
-const Serializer = require('./')
+const serializer = require('./')
 
-const normalizePaths = Serializer.normalizePaths
+const normalizePaths = serializer.normalizePaths
 
 describe('serializer', () => {
 
@@ -196,7 +196,7 @@ describe('serializer.test()', () => {
   it('returns true when val is a string and contains process.cwd', () => {
 
     const val = path.resolve(process.cwd(), 'a/path')
-    const result = Serializer.test(val)
+    const result = serializer.test(val)
     expect(result).toEqual(true)
 
   })
@@ -207,7 +207,7 @@ describe('serializer.test()', () => {
       property: path.resolve(process.cwd(), 'a/path'),
       property2: path.resolve('/no/dirname'),
     }
-    const result = Serializer.test(val)
+    const result = serializer.test(val)
     expect(result).toEqual(true)
 
   })
@@ -215,7 +215,7 @@ describe('serializer.test()', () => {
   it('returns true when val is an array with a property that contains process.cwd', () => {
 
     const val = [path.resolve(process.cwd(), 'a/path'), path.resolve('/no/dirname')]
-    const result = Serializer.test(val)
+    const result = serializer.test(val)
     expect(result).toEqual(true)
 
   })
@@ -224,7 +224,7 @@ describe('serializer.test()', () => {
 
     const val = new Error(`some error in ${path.resolve(process.cwd(), 'a/path')}`)
     val.code = 'HAS_CODE'
-    const result = Serializer.test(val)
+    const result = serializer.test(val)
     expect(result).toEqual(true)
 
   })
@@ -240,7 +240,7 @@ describe('serializer.test()', () => {
     catch (error) {
 
       // error is not an instanceof Error
-      const result = Serializer.test(error)
+      const result = serializer.test(error)
       expect(result).toEqual(true)
 
     }
@@ -250,7 +250,7 @@ describe('serializer.test()', () => {
   it('returns false when value does not change', () => {
 
     const val = 'some random string'
-    const result = Serializer.test(val)
+    const result = serializer.test(val)
     expect(result).toEqual(false)
 
   })
@@ -258,7 +258,7 @@ describe('serializer.test()', () => {
   it('returns false when value is NaN', () => {
 
     const val = NaN
-    const result = Serializer.test(val)
+    const result = serializer.test(val)
     expect(result).toEqual(false)
 
   })
@@ -273,7 +273,7 @@ describe('serializer.print()', () => {
     const ser = jest.fn()
     const val = path.resolve(process.cwd(), 'a/path')
     const expected = '<PROJECT_ROOT>/a/path'
-    Serializer.print(val, ser)
+    serializer.print(val, ser)
     expect(ser.mock.calls[0][0]).toEqual(expected)
 
   })
@@ -289,7 +289,7 @@ describe('serializer.print()', () => {
       property: '<PROJECT_ROOT>/a/path',
       property2: '/no/dirname',
     }
-    Serializer.print(val, ser)
+    serializer.print(val, ser)
     expect(ser.mock.calls[0][0]).toEqual(expected)
 
   })
@@ -299,7 +299,7 @@ describe('serializer.print()', () => {
     const ser = jest.fn()
     const val = [path.resolve(process.cwd(), 'a/path'), path.resolve('/no/dirname')]
     const expected = ['<PROJECT_ROOT>/a/path', '/no/dirname']
-    Serializer.print(val, ser)
+    serializer.print(val, ser)
     expect(ser.mock.calls[0][0]).toEqual(expected)
 
   })
@@ -309,7 +309,7 @@ describe('serializer.print()', () => {
     const ser = jest.fn()
     const val = new Error(`some error in ${path.resolve(process.cwd(), 'a/path')}`)
     const expected = 'some error in <PROJECT_ROOT>/a/path'
-    Serializer.print(val, ser)
+    serializer.print(val, ser)
     expect(ser.mock.calls[0][0].message).toEqual(expected)
 
   })
@@ -330,7 +330,7 @@ describe('serializer.print()', () => {
 
       const expectedMessage = `ENOENT: no such file or directory, open '<PROJECT_ROOT>/a/b/c/d/e/f/none.js'`
       const expectedCode = '<PROJECT_ROOT>/some/fake/error/code'
-      Serializer.print(error, ser)
+      serializer.print(error, ser)
       expect(ser.mock.calls[0][0].message).toEqual(expectedMessage)
       expect(ser.mock.calls[0][0].code).toEqual(expectedCode)
 
@@ -355,7 +355,7 @@ describe('serializer.print()', () => {
 
       const expectedMessage = `no path found`
       const expectedCode = '<PROJECT_ROOT>/some/fake/error/code'
-      Serializer.print(error, ser)
+      serializer.print(error, ser)
       expect(ser.mock.calls[0][0].message).toEqual(expectedMessage)
       expect(ser.mock.calls[0][0].code).toEqual(expectedCode)
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "snapshotSerializers": [
       "./"
     ],
-    "resetModules": true
+    "resetModules": true,
+    "resetMocks": true,
+    "restoreMocks": true
   },
   "scripts": {
     "coverage": "coveralls < coverage/lcov.info",


### PR DESCRIPTION
Been wanting to add these previously but needed an updated version of Jest. Adds automatic jest resets and lowercase `serializer` variable name (not a constructor).

This PR doesn't need a version bump as it only changes tests.

FYI when removing ``node_modules`` and running ``node ./bin/yarn-1.5.1.js``, ~230 files are added to ``.npm-packages-offline-cache`` on the latest [``master branch``](https://github.com/tribou/jest-serializer-path/tree/9b4aeaa15a4c06831de952523e630cc914f85c13). Unsure how to fix that correctly.