### PR TITLE
remove eslint no-param-reassign disable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint-disable no-param-reassign */
-
 const slash = require('slash')
 const cloneDeep = require('lodash.clonedeep')
 const isError = require('lodash.iserror')


### PR DESCRIPTION
No longer needed as of https://github.com/tribou/jest-serializer-path/pull/25, and should now be a linting error.