### PR TITLE
replace node_modules with <NODE_MODULES>

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ All absolute paths will now be converted and saved in snapshots like so:
 
 `/path/to/user-home/nested/home` => `<HOME_DIR>/nested/home`
 
+`/path/to/my-proj/node_modules/some-package/` => `<NODE_MODULES>/some-package/`
+
 #### Caveats
 
 *   All single backslashes (`\`) will be replaced by a forward slash (`/`).

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,6 +93,15 @@ function normalizePaths(value) {
   const homeRealRelativeToTemp = path.relative(tempDir, homeDirReal);
 
   const runner = [
+    // replace node_modules with NODE_MODULES
+    val => {
+      if (/node_modules/.test(val) === false) {
+        return val;
+      }
+
+      return `<NODE_MODULES>${val.split("node_modules").pop()}`;
+    },
+
     // Replace process.cwd with <PROJECT_ROOT>
     val => val.split(cwdReal).join("<PROJECT_ROOT>"),
     val => val.split(cwd).join("<PROJECT_ROOT>"),

--- a/lib/index_test.js
+++ b/lib/index_test.js
@@ -445,6 +445,23 @@ describe("normalizePaths", () => {
     expect(normalized).toEqual("<HOME_DIR>/some/nested/dir");
   });
 
+  it("replaces node_modules with <NODE_MODULES>", () => {
+    const value = path.resolve(process.cwd(), "node_modules/some/nested/dir");
+
+    const normalized = normalizePaths(value);
+    expect(normalized).toEqual("<NODE_MODULES>/some/nested/dir");
+  });
+
+  it("replaces node_modules nested inside node_modules with single <NODE_MODULES>", () => {
+    const value = path.resolve(
+      process.cwd(),
+      "node_modules/one/node_modules/some/nested/dir"
+    );
+
+    const normalized = normalizePaths(value);
+    expect(normalized).toEqual("<NODE_MODULES>/some/nested/dir");
+  });
+
   describe("symlinks", () => {
     const tempDir = path.resolve(os.tmpdir(), "jest-serializer-path");
 


### PR DESCRIPTION
Because node_modules are not consistent I found some issues where my snapshots were failing. This makes all node_modules under a single `<NODE_MODULES>` tag.